### PR TITLE
Fix img urls

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -13,7 +13,7 @@ OpenURI::Cache.cache_path = '.cache'
 @BASE = 'http://www.parliament.gov.sl/dnn5/AboutUs/MembersofParliament.aspx'
 
 def noko_for(url)
-  Nokogiri::HTML(open(url).read) 
+  Nokogiri::HTML(open(url).read)
 end
 
 def scrape_list(url)
@@ -21,7 +21,7 @@ def scrape_list(url)
   noko.css('table.telerik-reTable-1 td img').each do |img|
     cell = img.at_xpath('./following::td')
     rows = cell.text.split("\r\n").map { |t| t.gsub(/[[:space:]]+/, ' ').strip }.reject(&:empty?)
-    data = { 
+    data = {
       name: rows[0],
       image: img.attr('src'),
       term: '2-4',

--- a/scraper.rb
+++ b/scraper.rb
@@ -23,9 +23,10 @@ def scrape_list(url)
     rows = cell.text.split("\r\n").map { |t| t.gsub(/[[:space:]]+/, ' ').strip }.reject(&:empty?)
     data = { 
       name: rows[0],
-      image: URI.join(@BASE, URI.escape(img.attr('src'))).to_s,
+      image: img.attr('src'),
       term: '2-4',
     }
+    data[:image] = URI.join(@BASE, URI.encode(URI.decode(data[:image])).gsub("[","%5B").gsub("]","%5D")).to_s unless data[:image].to_s.empty?
     if rows[1].include? 'Constituency'
       data[:area] = rows[2..3].join ", "
       data[:party] = rows[4]


### PR DESCRIPTION
This PR fixes img urls: first it unescapes the img url then escapes it to avoid escaping twice

Some image links were working and others didn't randomly. It was
because some links came already escaped from the upstream source
and we were escaping all urls indiscriminately.

Closes https://github.com/everypolitician/everypolitician-data/issues/18587
