### PR TITLE
Add message to output reminding that we're not scraping the site

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -52,4 +52,5 @@ ScraperWiki.save_sqlite([:id], term, 'terms')
 
 # Weird ASP thing going on with browser detection so just cache the page
 # for now
+puts "*** scraping local file (within scraper repo), not remote website!"
 scrape_list('MembersofParliament.aspx')


### PR DESCRIPTION
It's caught me out; this isn't really scraping the site but doesn't
tell me. So maybe next time I'll spot this behaviour in the morph
output when I wonder what happened.

Obviously, when hard-coded `scrape_list` argument is updated we
can remove the message.
